### PR TITLE
Remove redundant ‘descriptor_dim’ configuration value in Pytorch SuperPoint class

### DIFF
--- a/superpoint_pytorch.py
+++ b/superpoint_pytorch.py
@@ -68,7 +68,6 @@ class VGGBlock(nn.Sequential):
 
 class SuperPoint(nn.Module):
     default_conf = {
-        "descriptor_dim": 256,
         "nms_radius": 4,
         "max_num_keypoints": None,
         "detection_threshold": 0.005,


### PR DESCRIPTION
This PR addresses a minor issue in the Pytorch SuperPoint class configuration. The `default_conf` dictionary currently includes a redundant key `descriptor_dim`, which appears twice. This update removes the duplicate entry to ensure cleaner and more maintainable code.
- Removed the redundant "descriptor_dim": 256 key from the default_conf dictionary.
- Verified that the functionality of the model remains unaffected by this change.