### PR TITLE
Enable import of sub-packages for dataset creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(name='superpoint',
       version="0.0",
-      packages=['superpoint'])
+      packages=find_packages(include=['superpoint', 'superpoint.*'])
+)


### PR DESCRIPTION
I wanted to implement the MagicPoint paper which uses the "Synthetic Shapes Dataset" as well (or as implemented here, dynamic shape generation using OpenCV). However the `setup.py` as currently implemented just installs the root package, no sub-packages.

This change will make sure to also install the sub-packages.